### PR TITLE
Add more env hook values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "structured-logger-railway"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     { name = "Nikita Yastreb", email = "yastrebnikita723@gmail.com" },
     { name = "Patrick Ward", email = "pward17@gmail.com" },

--- a/src/structured_logger/__init__.py
+++ b/src/structured_logger/__init__.py
@@ -56,7 +56,7 @@ try:
 except ImportError:
     SENTRY_INTEGRATION_AVAILABLE = False
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Nikita Yastreb"
 __email__ = "yastrebnikita723@gmail.com"
 

--- a/src/structured_logger/_version.py
+++ b/src/structured_logger/_version.py
@@ -1,3 +1,3 @@
 """Version information for structured-logger package."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/structured_logger/logger.py
+++ b/src/structured_logger/logger.py
@@ -48,14 +48,14 @@ class LoggerConfig:
     # Environment detection
     production_env_vars: List[str] = field(
         default_factory=lambda: [
-            "RAILWAY_ENVIRONMENT",
+            "RAILWAY_ENVIRONMENT_NAME",
             "ENV",
             "ENVIRONMENT",
             "NODE_ENV",
         ]
     )
     production_env_values: List[str] = field(
-        default_factory=lambda: ["prod", "production", "staging"]
+        default_factory=lambda: ["prod", "production", "staging", "dev"]
     )
 
     # Log level configuration


### PR DESCRIPTION
This pull request updates the version of the `structured-logger-railway` package to 1.4.1 and makes minor improvements to environment detection logic. The most significant changes are related to environment variable handling for production detection.

Version bump:

* Updated the package version to `1.4.1` in `pyproject.toml`, `src/structured_logger/__init__.py`, and `src/structured_logger/_version.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-cda65228454152e1eb4ce79100342104d5f5ba3647ef84fc06d6dc436fc1e36eL59-R59) [[3]](diffhunk://#diff-85ed0d38d62a13f2d3d9687b1809be69cc3b086207c292b7e22cfb0e46f98b97L3-R3)

Environment detection improvements:

* Changed the default production environment variable from `"RAILWAY_ENVIRONMENT"` to `"RAILWAY_ENVIRONMENT_NAME"` and added `"dev"` to the list of recognized production environment values in the `LoggerConfig` class (`src/structured_logger/logger.py`).